### PR TITLE
feat: add optional temporary preview links

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,16 @@ import YourDisplayProducts from './YourDisplayProducts.vue'
 
 Copy the reference picker from `src/tests/TestComponents/DemoDisplayProductsTest.vue` and swap static JSON for your API. Full walkthrough: [Display Products documentation](https://myissue-studio.github.io/vue-website-page-builder/display-products).
 
+### Optional temporary preview links
+
+Enable `showTemporaryPreviewButton` to let editors publish the same standalone HTML export to a public [Temp.md](https://temp.md) preview link:
+
+```vue
+<PageBuilder :showTemporaryPreviewButton="true" />
+```
+
+The option is off by default. Publishing only happens after an explicit click, the link expires after 7 days, and its scoped update token is stored in the browser so later publishes update the same URL. Editors can copy, open, update, or permanently remove the preview from the Download HTML settings. This is separate from the existing `showPublishButton` callback and does not replace your production publishing workflow.
+
 The package does **not** include cart, checkout, or inventory — by design. You keep your ecommerce stack; the builder handles layout and visual editing.
 
 ## Who This Is For

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@myissue/vue-website-page-builder",
-  "version": "3.5.72",
+  "version": "3.5.74",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@myissue/vue-website-page-builder",
-      "version": "3.5.72",
+      "version": "3.5.74",
       "license": "MIT",
       "dependencies": {
         "@tiptap/extension-link": "^3.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myissue/vue-website-page-builder",
-  "version": "3.5.72",
+  "version": "3.5.74",
   "description": "Free open-source Vue 3 page builder and drag-and-drop visual editor for ecommerce admin, multi-tenant SaaS, and headless CMS. Self-hosted Builder.io / GrapesJS-style alternative with custom media library and product catalog integration.",
   "type": "module",
   "main": "./dist/vue-website-page-builder.umd.cjs",

--- a/src/Components/PageBuilder/EditorMenu/Editables/DownloadHtmlSettingsSection.vue
+++ b/src/Components/PageBuilder/EditorMenu/Editables/DownloadHtmlSettingsSection.vue
@@ -1,14 +1,27 @@
 <script setup lang="ts">
+import { computed, inject } from 'vue'
+import type { ComputedRef } from 'vue'
 import EditorAccordion from '../EditorAccordion.vue'
 import PageBuilderSettings from '../../Settings/PageBuilderSettings.vue'
 import { useTranslations } from '../../../../composables/useTranslations'
 
 const { translate } = useTranslations()
+
+const showTemporaryPreviewButton = inject<ComputedRef<boolean>>(
+  'showTemporaryPreviewButton',
+  computed(() => false),
+)
+
+const sectionTitle = computed(() =>
+  showTemporaryPreviewButton.value
+    ? translate('Export & preview')
+    : translate('Download HTML'),
+)
 </script>
 
 <template>
-  <EditorAccordion>
-    <template #title>{{ translate('Download HTML') }}</template>
+  <EditorAccordion :default-expanded="showTemporaryPreviewButton">
+    <template #title>{{ sectionTitle }}</template>
     <template #content>
       <PageBuilderSettings embedded-section="download" />
     </template>

--- a/src/Components/PageBuilder/EditorMenu/RightSidebarEditor.vue
+++ b/src/Components/PageBuilder/EditorMenu/RightSidebarEditor.vue
@@ -261,8 +261,8 @@ const closeHTMLSettings = async function () {
       </div>
 
       <div v-show="activeTab === 'tools'" class="pbx-flex pbx-flex-col pbx-gap-2">
-        <OverviewSettingsSection />
         <DownloadHtmlSettingsSection />
+        <OverviewSettingsSection />
         <SelectedHtmlSettingsSection />
       </div>
     </div>

--- a/src/Components/PageBuilder/Settings/PageBuilderSettings.vue
+++ b/src/Components/PageBuilder/Settings/PageBuilderSettings.vue
@@ -842,7 +842,11 @@ function formatExpiry(expiresAt?: string | null): string {
           }}
         </p>
         <div class="pbx-editorFieldGroup">
-          <button @click="handleDownloadHTML" type="button" class="pbx-myPrimaryButton">
+          <button
+            @click="handleDownloadHTML"
+            type="button"
+            class="pbx-myPrimaryButton pbx-w-full sm:pbx-w-full"
+          >
             <span>
               {{ translate('Download HTML file') }}
             </span>
@@ -872,7 +876,7 @@ function formatExpiry(expiresAt?: string | null): string {
           <button
             @click="handlePublishTemporaryPreview"
             type="button"
-            class="pbx-myPrimaryButton pbx-mt-3"
+            class="pbx-myPrimaryButton pbx-mt-3 pbx-w-full sm:pbx-w-full"
             :disabled="temporaryPreviewLoading || temporaryPreviewRemoving"
           >
             {{
@@ -892,14 +896,14 @@ function formatExpiry(expiresAt?: string | null): string {
               class="pbx-text-xs pbx-text-gray-700 pbx-break-all pbx-underline"
               >{{ temporaryPreview.canonicalUrl }}</a
             >
-            <p v-if="temporaryPreview.expiresAt" class="pbx-editorSectionDesc">
+            <p v-if="temporaryPreview.expiresAt" class="pbx-editorSectionDesc pbx-mb-0">
               {{ translate('Expires') }}: {{ formatExpiry(temporaryPreview.expiresAt) }}
             </p>
-            <div class="pbx-flex pbx-flex-wrap pbx-gap-2">
+            <div class="pbx-flex pbx-flex-col pbx-gap-2">
               <button
                 @click="handleCopyTemporaryPreview"
                 type="button"
-                class="pbx-mySecondaryButton"
+                class="pbx-mySecondaryButton pbx-w-full sm:pbx-w-full"
               >
                 {{ translate('Copy link') }}
               </button>
@@ -907,14 +911,14 @@ function formatExpiry(expiresAt?: string | null): string {
                 :href="temporaryPreview.canonicalUrl"
                 target="_blank"
                 rel="noopener noreferrer"
-                class="pbx-mySecondaryButton pbx-no-underline"
+                class="pbx-mySecondaryButton pbx-w-full sm:pbx-w-full pbx-no-underline"
               >
                 {{ translate('Open preview') }}
               </a>
               <button
                 @click="handleRemoveTemporaryPreview"
                 type="button"
-                class="pbx-mySecondaryButton"
+                class="pbx-mySecondaryButton pbx-w-full sm:pbx-w-full"
                 :disabled="temporaryPreviewLoading || temporaryPreviewRemoving"
               >
                 {{

--- a/src/Components/PageBuilder/Settings/PageBuilderSettings.vue
+++ b/src/Components/PageBuilder/Settings/PageBuilderSettings.vue
@@ -888,17 +888,42 @@ function formatExpiry(expiresAt?: string | null): string {
             }}
           </button>
 
-          <div v-if="temporaryPreview" class="pbx-mt-4 pbx-flex pbx-flex-col pbx-gap-2">
-            <a
-              :href="temporaryPreview.canonicalUrl"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="pbx-text-xs pbx-text-gray-700 pbx-break-all pbx-underline"
-              >{{ temporaryPreview.canonicalUrl }}</a
+          <div
+            v-if="temporaryPreview"
+            class="pbx-mt-4 pbx-flex pbx-flex-col pbx-gap-3"
+          >
+            <div
+              class="pbx-rounded-xl pbx-border pbx-border-solid pbx-border-gray-200 pbx-bg-gray-50 pbx-px-3.5 pbx-py-3"
             >
-            <p v-if="temporaryPreview.expiresAt" class="pbx-editorSectionDesc pbx-mb-0">
-              {{ translate('Expires') }}: {{ formatExpiry(temporaryPreview.expiresAt) }}
-            </p>
+              <p
+                class="pbx-m-0 pbx-mb-1.5 pbx-text-[10px] pbx-font-semibold pbx-uppercase pbx-tracking-wider pbx-text-gray-400"
+              >
+                {{ translate('Live link') }}
+              </p>
+              <a
+                :href="temporaryPreview.canonicalUrl"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="pbx-block pbx-text-sm pbx-font-medium pbx-text-gray-900 pbx-break-all pbx-no-underline hover:pbx-text-myPrimaryLinkColor"
+              >
+                {{ temporaryPreview.canonicalUrl }}
+              </a>
+              <div
+                v-if="temporaryPreview.expiresAt"
+                class="pbx-mt-2.5 pbx-flex pbx-items-center pbx-gap-1.5 pbx-text-xs pbx-text-gray-500"
+              >
+                <span class="material-symbols-outlined pbx-text-base pbx-leading-none" aria-hidden="true">
+                  schedule
+                </span>
+                <span>
+                  {{ translate('Expires') }}
+                  <span class="pbx-font-medium pbx-text-gray-700">{{
+                    formatExpiry(temporaryPreview.expiresAt)
+                  }}</span>
+                </span>
+              </div>
+            </div>
+
             <div class="pbx-flex pbx-flex-col pbx-gap-2">
               <button
                 @click="handleCopyTemporaryPreview"

--- a/src/Components/PageBuilder/Settings/PageBuilderSettings.vue
+++ b/src/Components/PageBuilder/Settings/PageBuilderSettings.vue
@@ -1,12 +1,24 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, inject, ref } from 'vue'
+import type { ComputedRef } from 'vue'
 import { sharedPageBuilderStore } from '../../../stores/shared-store'
 import { isEmptyObject } from '../../../utils/is-empty-object'
 import { version } from '../../../../package.json'
 import { useTranslations } from '../../../composables/useTranslations'
 import { useToast } from '../../../composables/useToast'
-import { extractCleanHTMLFromPageBuilder } from '../../../utils/builder/extract-clean-html'
 import SelectedHtmlInspector from '../EditorMenu/Editables/SelectedHtmlInspector.vue'
+import {
+  downloadStandaloneHtml,
+  getStandalonePageHtml,
+} from '../../../utils/builder/standalone-html'
+import {
+  isExpiredPreviewCredential,
+  loadTemporaryPreview,
+  publishTemporaryPreview,
+  removeTemporaryPreview,
+  saveTemporaryPreview,
+} from '../../../utils/builder/temp-preview'
+import type { TemporaryPreview } from '../../../utils/builder/temp-preview'
 
 type EmbeddedSection =
   | 'overviewApp'
@@ -21,6 +33,10 @@ const props = defineProps<{
 
 const { translate } = useTranslations()
 const { showToast } = useToast()
+const showTemporaryPreviewButton = inject<ComputedRef<boolean>>(
+  'showTemporaryPreviewButton',
+  computed(() => false),
+)
 
 const isEmbedded = computed(() => Boolean(props.embeddedSection))
 
@@ -72,86 +88,103 @@ const showSelectedHtml = computed(
     (!props.embeddedSection && selectedTab.value === 'viewHTMLConfig'),
 )
 
-function generateHTML(filename: string, HTML: string) {
-  const existingStyles = Array.from(document.querySelectorAll('style, link[rel="stylesheet"]'))
-    .map((style) => {
-      if (style.tagName === 'STYLE') {
-        return style.outerHTML
-      } else if (style.tagName === 'LINK') {
-        return `<link rel="stylesheet" href="${(style as HTMLLinkElement).href}">`
-      }
-      return ''
-    })
-    .join('\n')
+const temporaryPreviewStorageKey = computed(() => {
+  const resourceId = getPageBuilderConfig.value?.resourceData?.id
+  const scope = pageBuilderStateStore.getLocalStorageItemName ?? resourceId ?? 'page'
+  return `vue-website-page-builder:temp-preview:${String(scope)}`
+})
+const temporaryPreview = ref<TemporaryPreview | null>(
+  loadTemporaryPreview(temporaryPreviewStorageKey.value),
+)
+const temporaryPreviewLoading = ref(false)
+const temporaryPreviewRemoving = ref(false)
+const temporaryPreviewError = ref('')
 
-  const customCSS = `
-      <style>
-        #pagebuilder blockquote,
-        #pagebuilder dl,
-        #pagebuilder dd,
-        #pagebuilder pre,
-        #pagebuilder hr,
-        #pagebuilder figure,
-        #pagebuilder p,
-        #pagebuilder h1,
-        #pagebuilder h2,
-        #pagebuilder h3,
-        #pagebuilder h4,
-        #pagebuilder h5,
-        #pagebuilder h6,
-        #pagebuilder ul,
-        #pagebuilder ol {
-          margin: 0;
-          padding: 0;
-        }
-      </style>
-    `
-
-  const css = `${existingStyles}\n${customCSS}`
-
-  const fullHTML = `
-        <!DOCTYPE html>
-        <html lang="en">
-        <head>
-            <meta charset="UTF-8">
-            <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <title>Downloaded HTML</title>
-            ${css}
-        </head>
-        <body>
-            <div id="pagebuilder" class="pbx-font-sans pbx-text-black">
-                ${HTML}
-            </div>
-        </body>
-        </html>
-    `
-
-  const element = document.createElement('a')
-  element.setAttribute('href', 'data:text/html;charset=utf-8,' + encodeURIComponent(fullHTML))
-  element.setAttribute('download', filename)
-  element.style.display = 'none'
-  document.body.appendChild(element)
-  element.click()
-  document.body.removeChild(element)
+function getCurrentStandaloneHtml(): string | null {
+  const pagebuilder = document.getElementById('pagebuilder')
+  if (!pagebuilder) return null
+  return getStandalonePageHtml(pagebuilder, document)
 }
 
 function handleDownloadHTML() {
-  const pagebuilder = document.getElementById('pagebuilder')
-  if (!pagebuilder) return
-
-  let html = extractCleanHTMLFromPageBuilder(pagebuilder)
-
-  const tempDiv = document.createElement('div')
-  tempDiv.innerHTML = html
-
-  tempDiv.querySelectorAll('[hovered], [selected]').forEach((el) => {
-    el.removeAttribute('hovered')
-    el.removeAttribute('selected')
-  })
-
-  html = tempDiv.innerHTML
-  generateHTML('downloaded_html.html', html)
+  const html = getCurrentStandaloneHtml()
+  if (!html) return
+  downloadStandaloneHtml('downloaded_html.html', html)
   showToast(translate('HTML file downloaded'), 'success')
+}
+
+async function handlePublishTemporaryPreview() {
+  const html = getCurrentStandaloneHtml()
+  if (!html) return
+  temporaryPreviewLoading.value = true
+  temporaryPreviewError.value = ''
+  let wasUpdate = Boolean(temporaryPreview.value)
+
+  try {
+    let published: TemporaryPreview
+    try {
+      published = await publishTemporaryPreview(html, temporaryPreview.value ?? undefined)
+    } catch (error) {
+      if (!temporaryPreview.value || !isExpiredPreviewCredential(error)) throw error
+      temporaryPreview.value = null
+      wasUpdate = false
+      saveTemporaryPreview(temporaryPreviewStorageKey.value, null)
+      published = await publishTemporaryPreview(html)
+    }
+    temporaryPreview.value = published
+    saveTemporaryPreview(temporaryPreviewStorageKey.value, published)
+    showToast(
+      translate(wasUpdate ? 'Temporary preview updated' : 'Temporary preview published'),
+      'success',
+    )
+  } catch (error) {
+    temporaryPreviewError.value =
+      error instanceof Error ? error.message : translate('Could not publish temporary preview')
+    showToast(translate('Could not publish temporary preview'), 'error')
+  } finally {
+    temporaryPreviewLoading.value = false
+  }
+}
+
+async function handleCopyTemporaryPreview() {
+  if (!temporaryPreview.value) return
+  try {
+    await navigator.clipboard.writeText(temporaryPreview.value.canonicalUrl)
+    showToast(translate('Preview link copied'), 'success')
+  } catch {
+    showToast(translate('Clipboard unavailable'), 'error')
+  }
+}
+
+async function handleRemoveTemporaryPreview() {
+  if (
+    !temporaryPreview.value ||
+    !window.confirm(translate('Remove this temporary preview permanently?'))
+  ) {
+    return
+  }
+
+  temporaryPreviewRemoving.value = true
+  temporaryPreviewError.value = ''
+  try {
+    await removeTemporaryPreview(temporaryPreview.value)
+    temporaryPreview.value = null
+    saveTemporaryPreview(temporaryPreviewStorageKey.value, null)
+    showToast(translate('Temporary preview removed'), 'success')
+  } catch (error) {
+    temporaryPreviewError.value =
+      error instanceof Error ? error.message : translate('Could not remove temporary preview')
+    showToast(translate('Could not remove temporary preview'), 'error')
+  } finally {
+    temporaryPreviewRemoving.value = false
+  }
+}
+
+function formatExpiry(expiresAt?: string | null): string {
+  if (!expiresAt) return ''
+  return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(
+    new Date(expiresAt),
+  )
 }
 </script>
 
@@ -814,6 +847,85 @@ function handleDownloadHTML() {
               {{ translate('Download HTML file') }}
             </span>
           </button>
+        </div>
+
+        <div
+          v-if="showTemporaryPreviewButton"
+          class="pbx-editorFieldGroup pbx-mt-6 pbx-pt-6 pbx-border-0 pbx-border-solid pbx-border-t pbx-border-gray-200"
+        >
+          <h4 class="pbx-myQuaternaryHeader">{{ translate('Temporary preview') }}</h4>
+          <p class="pbx-editorSectionDesc pbx-mt-2">
+            {{
+              translate(
+                'Publish a public preview link that expires after 7 days. Nothing is uploaded until you click publish.',
+              )
+            }}
+            <a
+              href="https://temp.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="pbx-text-gray-700 pbx-underline"
+              >Temp.md</a
+            >
+          </p>
+
+          <button
+            @click="handlePublishTemporaryPreview"
+            type="button"
+            class="pbx-myPrimaryButton pbx-mt-3"
+            :disabled="temporaryPreviewLoading || temporaryPreviewRemoving"
+          >
+            {{
+              temporaryPreviewLoading
+                ? translate('Publishing...')
+                : translate(
+                    temporaryPreview ? 'Update temporary preview' : 'Publish temporary preview',
+                  )
+            }}
+          </button>
+
+          <div v-if="temporaryPreview" class="pbx-mt-4 pbx-flex pbx-flex-col pbx-gap-2">
+            <a
+              :href="temporaryPreview.canonicalUrl"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="pbx-text-xs pbx-text-gray-700 pbx-break-all pbx-underline"
+              >{{ temporaryPreview.canonicalUrl }}</a
+            >
+            <p v-if="temporaryPreview.expiresAt" class="pbx-editorSectionDesc">
+              {{ translate('Expires') }}: {{ formatExpiry(temporaryPreview.expiresAt) }}
+            </p>
+            <div class="pbx-flex pbx-flex-wrap pbx-gap-2">
+              <button
+                @click="handleCopyTemporaryPreview"
+                type="button"
+                class="pbx-mySecondaryButton"
+              >
+                {{ translate('Copy link') }}
+              </button>
+              <a
+                :href="temporaryPreview.canonicalUrl"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="pbx-mySecondaryButton pbx-no-underline"
+              >
+                {{ translate('Open preview') }}
+              </a>
+              <button
+                @click="handleRemoveTemporaryPreview"
+                type="button"
+                class="pbx-mySecondaryButton"
+                :disabled="temporaryPreviewLoading || temporaryPreviewRemoving"
+              >
+                {{
+                  temporaryPreviewRemoving ? translate('Removing...') : translate('Remove preview')
+                }}
+              </button>
+            </div>
+          </div>
+          <p v-if="temporaryPreviewError" class="pbx-mt-3 pbx-text-xs pbx-text-red-700">
+            {{ temporaryPreviewError }}
+          </p>
         </div>
       </div>
       <div v-else>

--- a/src/PageBuilder/PageBuilder.vue
+++ b/src/PageBuilder/PageBuilder.vue
@@ -71,6 +71,7 @@ const {
  * @property {Object|null} DisplayProducts - Optional custom product picker (replaces built-in sample catalog)
  * @property {boolean} enableDefaultProducts - Show built-in sample catalog when DisplayProducts is omitted (default true)
  * @property {Object|null} CustomBuilderComponents - Custom component
+ * @property {boolean} showTemporaryPreviewButton - Show the optional Temp.md preview action
  * @property {Object} configPageBuilder - Configuration object containing:
  */
 const props = defineProps({
@@ -98,6 +99,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  showTemporaryPreviewButton: {
+    type: Boolean,
+    default: false,
+  },
 })
 
 const { translate, loadTranslations } = useTranslations()
@@ -116,6 +121,10 @@ provide('internalPinia', internalPinia)
 provide('CustomMediaComponent', props.CustomMediaLibraryComponent)
 provide('DisplayProductsComponent', props.DisplayProducts)
 provide('CustomBuilderComponents', props.CustomBuilderComponents)
+provide(
+  'showTemporaryPreviewButton',
+  computed(() => props.showTemporaryPreviewButton),
+)
 
 /** Products UI: custom picker and/or built-in sample catalog (see enableDefaultProducts). */
 const showProductsFeature = computed(

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -652,5 +652,22 @@
   "Modern": "حديث",
   "Bold type and tighter spacing": "خط عريض ومسافات أقرب",
   "Minimal": "بسيط",
-  "Quiet type and more whitespace": "خط هادئ ومزيد من المساحة"
+  "Quiet type and more whitespace": "خط هادئ ومزيد من المساحة",
+  "Temporary preview": "Temporary preview",
+  "Publish a public preview link that expires after 7 days. Nothing is uploaded until you click publish.": "Publish a public preview link that expires after 7 days. Nothing is uploaded until you click publish.",
+  "Publish temporary preview": "Publish temporary preview",
+  "Update temporary preview": "Update temporary preview",
+  "Publishing...": "Publishing...",
+  "Removing...": "Removing...",
+  "Copy link": "Copy link",
+  "Open preview": "Open preview",
+  "Remove preview": "Remove preview",
+  "Preview link copied": "Preview link copied",
+  "Temporary preview published": "Temporary preview published",
+  "Temporary preview updated": "Temporary preview updated",
+  "Temporary preview removed": "Temporary preview removed",
+  "Expires": "Expires",
+  "Could not publish temporary preview": "Could not publish temporary preview",
+  "Could not remove temporary preview": "Could not remove temporary preview",
+  "Remove this temporary preview permanently?": "Remove this temporary preview permanently?"
 }

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -260,6 +260,7 @@
   "Apply styles that affect the entire page. These settings include global font family, text color, background color, and other universal styles that apply to all sections.": "طبق أنماطًا تؤثر على الصفحة بأكملها. تشمل هذه الإعدادات عائلة الخطوط العامة، ولون النص، ولون الخلفية، والأنماط العامة الأخرى التي تنطبق على جميع الأقسام.",
   "Update Page Styles": "تحديث أنماط الصفحة",
   "Download HTML": "تنزيل HTML",
+  "Export & preview": "Export & preview",
   "Export the entire page as a standalone HTML file. This includes all sections, content, and applied styles, making it ready for use or integration elsewhere.": "صدر الصفحة بأكملها كملف HTML مستقل. يشمل ذلك جميع الأقسام والمحتوى والأنماط المطبقة، مما يجعلها جاهزة للاستخدام أو التكامل في مكان آخر.",
   "Download HTML file": "تنزيل ملف HTML",
   "Loading...": "جارٍ التحميل...",

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -666,6 +666,7 @@
   "Temporary preview published": "Temporary preview published",
   "Temporary preview updated": "Temporary preview updated",
   "Temporary preview removed": "Temporary preview removed",
+  "Live link": "Live link",
   "Expires": "Expires",
   "Could not publish temporary preview": "Could not publish temporary preview",
   "Could not remove temporary preview": "Could not remove temporary preview",

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -659,5 +659,22 @@
   "Modern": "Modern",
   "Bold type and tighter spacing": "Fed typografi og tættere spacing",
   "Minimal": "Minimal",
-  "Quiet type and more whitespace": "Roligt typografi og mere luft"
+  "Quiet type and more whitespace": "Roligt typografi og mere luft",
+  "Temporary preview": "Temporary preview",
+  "Publish a public preview link that expires after 7 days. Nothing is uploaded until you click publish.": "Publish a public preview link that expires after 7 days. Nothing is uploaded until you click publish.",
+  "Publish temporary preview": "Publish temporary preview",
+  "Update temporary preview": "Update temporary preview",
+  "Publishing...": "Publishing...",
+  "Removing...": "Removing...",
+  "Copy link": "Copy link",
+  "Open preview": "Open preview",
+  "Remove preview": "Remove preview",
+  "Preview link copied": "Preview link copied",
+  "Temporary preview published": "Temporary preview published",
+  "Temporary preview updated": "Temporary preview updated",
+  "Temporary preview removed": "Temporary preview removed",
+  "Expires": "Expires",
+  "Could not publish temporary preview": "Could not publish temporary preview",
+  "Could not remove temporary preview": "Could not remove temporary preview",
+  "Remove this temporary preview permanently?": "Remove this temporary preview permanently?"
 }

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -673,6 +673,7 @@
   "Temporary preview published": "Temporary preview published",
   "Temporary preview updated": "Temporary preview updated",
   "Temporary preview removed": "Temporary preview removed",
+  "Live link": "Live link",
   "Expires": "Expires",
   "Could not publish temporary preview": "Could not publish temporary preview",
   "Could not remove temporary preview": "Could not remove temporary preview",

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -268,6 +268,7 @@
   "Apply styles that affect the entire page. These settings include global font family, text color, background color, and other universal styles that apply to all sections.": "Anvend stile, der påvirker hele siden. Disse indstillinger inkluderer global skrifttypefamilie, tekstfarve, baggrundsfarve og andre universelle stile, der gælder for alle sektioner.",
   "Update Page Styles": "Opdater sidestile",
   "Download HTML": "Download HTML",
+  "Export & preview": "Export & preview",
   "Export the entire page as a standalone HTML file. This includes all sections, content, and applied styles, making it ready for use or integration elsewhere.": "Eksporter hele siden som en selvstændig HTML-fil. Dette inkluderer alle sektioner, indhold og anvendte stile, hvilket gør den klar til brug eller integration andre steder.",
   "Download HTML file": "Download HTML-fil",
   "Loading...": "Indlæser...",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -652,5 +652,22 @@
   "Modern": "Modern",
   "Bold type and tighter spacing": "Fette Schrift und engere Abstände",
   "Minimal": "Minimal",
-  "Quiet type and more whitespace": "Ruhige Typografie und mehr Weißraum"
+  "Quiet type and more whitespace": "Ruhige Typografie und mehr Weißraum",
+  "Temporary preview": "Temporary preview",
+  "Publish a public preview link that expires after 7 days. Nothing is uploaded until you click publish.": "Publish a public preview link that expires after 7 days. Nothing is uploaded until you click publish.",
+  "Publish temporary preview": "Publish temporary preview",
+  "Update temporary preview": "Update temporary preview",
+  "Publishing...": "Publishing...",
+  "Removing...": "Removing...",
+  "Copy link": "Copy link",
+  "Open preview": "Open preview",
+  "Remove preview": "Remove preview",
+  "Preview link copied": "Preview link copied",
+  "Temporary preview published": "Temporary preview published",
+  "Temporary preview updated": "Temporary preview updated",
+  "Temporary preview removed": "Temporary preview removed",
+  "Expires": "Expires",
+  "Could not publish temporary preview": "Could not publish temporary preview",
+  "Could not remove temporary preview": "Could not remove temporary preview",
+  "Remove this temporary preview permanently?": "Remove this temporary preview permanently?"
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -260,6 +260,7 @@
   "Apply styles that affect the entire page. These settings include global font family, text color, background color, and other universal styles that apply to all sections.": "Wenden Sie Stile an, die die gesamte Seite betreffen. Diese Einstellungen umfassen globale Schriftfamilie, Textfarbe, Hintergrundfarbe und andere universelle Stile, die auf alle Abschnitte angewendet werden.",
   "Update Page Styles": "Seitenstile aktualisieren",
   "Download HTML": "HTML herunterladen",
+  "Export & preview": "Export & preview",
   "Export the entire page as a standalone HTML file. This includes all sections, content, and applied styles, making it ready for use or integration elsewhere.": "Exportieren Sie die gesamte Seite als eigenständige HTML-Datei. Dies umfasst alle Abschnitte, Inhalte und angewendeten Stile, sodass sie für die Verwendung oder Integration an anderer Stelle bereit ist.",
   "Download HTML file": "HTML-Datei herunterladen",
   "Loading...": "Wird geladen...",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -666,6 +666,7 @@
   "Temporary preview published": "Temporary preview published",
   "Temporary preview updated": "Temporary preview updated",
   "Temporary preview removed": "Temporary preview removed",
+  "Live link": "Live link",
   "Expires": "Expires",
   "Could not publish temporary preview": "Could not publish temporary preview",
   "Could not remove temporary preview": "Could not remove temporary preview",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -291,6 +291,7 @@
   "Apply styles that affect the entire page. These settings include global font family, text color, background color, and other universal styles that apply to all sections.": "Apply styles that affect the entire page. These settings include global font family, text color, background color, and other universal styles that apply to all sections.",
   "Update Page Styles": "Update Page Styles",
   "Download HTML": "Download HTML",
+  "Export & preview": "Export & preview",
   "Export the entire page as a standalone HTML file. This includes all sections, content, and applied styles, making it ready for use or integration elsewhere.": "Export the entire page as a standalone HTML file. This includes all sections, content, and applied styles, making it ready for use or integration elsewhere.",
   "Download HTML file": "Download HTML File",
   "Loading...": "Loading...",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -691,6 +691,7 @@
   "Temporary preview published": "Temporary preview published",
   "Temporary preview updated": "Temporary preview updated",
   "Temporary preview removed": "Temporary preview removed",
+  "Live link": "Live link",
   "Expires": "Expires",
   "Could not publish temporary preview": "Could not publish temporary preview",
   "Could not remove temporary preview": "Could not remove temporary preview",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -677,5 +677,22 @@
   "Modern": "Modern",
   "Bold type and tighter spacing": "Bold type and tighter spacing",
   "Minimal": "Minimal",
-  "Quiet type and more whitespace": "Quiet type and more whitespace"
+  "Quiet type and more whitespace": "Quiet type and more whitespace",
+  "Temporary preview": "Temporary preview",
+  "Publish a public preview link that expires after 7 days. Nothing is uploaded until you click publish.": "Publish a public preview link that expires after 7 days. Nothing is uploaded until you click publish.",
+  "Publish temporary preview": "Publish temporary preview",
+  "Update temporary preview": "Update temporary preview",
+  "Publishing...": "Publishing...",
+  "Removing...": "Removing...",
+  "Copy link": "Copy link",
+  "Open preview": "Open preview",
+  "Remove preview": "Remove preview",
+  "Preview link copied": "Preview link copied",
+  "Temporary preview published": "Temporary preview published",
+  "Temporary preview updated": "Temporary preview updated",
+  "Temporary preview removed": "Temporary preview removed",
+  "Expires": "Expires",
+  "Could not publish temporary preview": "Could not publish temporary preview",
+  "Could not remove temporary preview": "Could not remove temporary preview",
+  "Remove this temporary preview permanently?": "Remove this temporary preview permanently?"
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -652,5 +652,22 @@
   "Modern": "Moderno",
   "Bold type and tighter spacing": "Tipografía bold y espaciado más compacto",
   "Minimal": "Minimalista",
-  "Quiet type and more whitespace": "Tipografía discreta y más espacio"
+  "Quiet type and more whitespace": "Tipografía discreta y más espacio",
+  "Temporary preview": "Temporary preview",
+  "Publish a public preview link that expires after 7 days. Nothing is uploaded until you click publish.": "Publish a public preview link that expires after 7 days. Nothing is uploaded until you click publish.",
+  "Publish temporary preview": "Publish temporary preview",
+  "Update temporary preview": "Update temporary preview",
+  "Publishing...": "Publishing...",
+  "Removing...": "Removing...",
+  "Copy link": "Copy link",
+  "Open preview": "Open preview",
+  "Remove preview": "Remove preview",
+  "Preview link copied": "Preview link copied",
+  "Temporary preview published": "Temporary preview published",
+  "Temporary preview updated": "Temporary preview updated",
+  "Temporary preview removed": "Temporary preview removed",
+  "Expires": "Expires",
+  "Could not publish temporary preview": "Could not publish temporary preview",
+  "Could not remove temporary preview": "Could not remove temporary preview",
+  "Remove this temporary preview permanently?": "Remove this temporary preview permanently?"
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -260,6 +260,7 @@
   "Apply styles that affect the entire page. These settings include global font family, text color, background color, and other universal styles that apply to all sections.": "Aplica estilos que afectan a toda la página. Estas configuraciones incluyen la familia de fuentes global, el color del texto, el color de fondo y otros estilos universales que se aplican a todas las secciones.",
   "Update Page Styles": "Actualizar estilos de página",
   "Download HTML": "Descargar HTML",
+  "Export & preview": "Export & preview",
   "Export the entire page as a standalone HTML file. This includes all sections, content, and applied styles, making it ready for use or integration elsewhere.": "Exporta toda la página como un archivo HTML independiente. Esto incluye todas las secciones, el contenido y los estilos aplicados, haciéndolo listo para usar o integrar en otro lugar.",
   "Download HTML file": "Descargar archivo HTML",
   "Loading...": "Cargando...",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -666,6 +666,7 @@
   "Temporary preview published": "Temporary preview published",
   "Temporary preview updated": "Temporary preview updated",
   "Temporary preview removed": "Temporary preview removed",
+  "Live link": "Live link",
   "Expires": "Expires",
   "Could not publish temporary preview": "Could not publish temporary preview",
   "Could not remove temporary preview": "Could not remove temporary preview",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -652,5 +652,22 @@
   "Modern": "Moderne",
   "Bold type and tighter spacing": "Typographie audacieuse et espacement resserré",
   "Minimal": "Minimal",
-  "Quiet type and more whitespace": "Typographie discrète et plus d’espace"
+  "Quiet type and more whitespace": "Typographie discrète et plus d’espace",
+  "Temporary preview": "Temporary preview",
+  "Publish a public preview link that expires after 7 days. Nothing is uploaded until you click publish.": "Publish a public preview link that expires after 7 days. Nothing is uploaded until you click publish.",
+  "Publish temporary preview": "Publish temporary preview",
+  "Update temporary preview": "Update temporary preview",
+  "Publishing...": "Publishing...",
+  "Removing...": "Removing...",
+  "Copy link": "Copy link",
+  "Open preview": "Open preview",
+  "Remove preview": "Remove preview",
+  "Preview link copied": "Preview link copied",
+  "Temporary preview published": "Temporary preview published",
+  "Temporary preview updated": "Temporary preview updated",
+  "Temporary preview removed": "Temporary preview removed",
+  "Expires": "Expires",
+  "Could not publish temporary preview": "Could not publish temporary preview",
+  "Could not remove temporary preview": "Could not remove temporary preview",
+  "Remove this temporary preview permanently?": "Remove this temporary preview permanently?"
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -260,6 +260,7 @@
   "Apply styles that affect the entire page. These settings include global font family, text color, background color, and other universal styles that apply to all sections.": "Appliquez des styles qui affectent l'ensemble de la page. Ces paramètres incluent la famille de polices globale, la couleur du texte, la couleur de fond et d'autres styles universels applicables à toutes les sections.",
   "Update Page Styles": "Mettre à jour les styles de page",
   "Download HTML": "Télécharger HTML",
+  "Export & preview": "Export & preview",
   "Export the entire page as a standalone HTML file. This includes all sections, content, and applied styles, making it ready for use or integration elsewhere.": "Exportez toute la page sous forme de fichier HTML autonome. Cela inclut toutes les sections, le contenu et les styles appliqués, prêt à l'usage ou à l'intégration ailleurs.",
   "Download HTML file": "Télécharger le fichier HTML",
   "Loading...": "Chargement...",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -666,6 +666,7 @@
   "Temporary preview published": "Temporary preview published",
   "Temporary preview updated": "Temporary preview updated",
   "Temporary preview removed": "Temporary preview removed",
+  "Live link": "Live link",
   "Expires": "Expires",
   "Could not publish temporary preview": "Could not publish temporary preview",
   "Could not remove temporary preview": "Could not remove temporary preview",

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -652,5 +652,22 @@
   "Modern": "आधुनिक",
   "Bold type and tighter spacing": "बोल्ड टाइप और सघन स्पेसिंग",
   "Minimal": "मिनिमल",
-  "Quiet type and more whitespace": "शांत टाइप और अधिक व्हाइटस्पेस"
+  "Quiet type and more whitespace": "शांत टाइप और अधिक व्हाइटस्पेस",
+  "Temporary preview": "Temporary preview",
+  "Publish a public preview link that expires after 7 days. Nothing is uploaded until you click publish.": "Publish a public preview link that expires after 7 days. Nothing is uploaded until you click publish.",
+  "Publish temporary preview": "Publish temporary preview",
+  "Update temporary preview": "Update temporary preview",
+  "Publishing...": "Publishing...",
+  "Removing...": "Removing...",
+  "Copy link": "Copy link",
+  "Open preview": "Open preview",
+  "Remove preview": "Remove preview",
+  "Preview link copied": "Preview link copied",
+  "Temporary preview published": "Temporary preview published",
+  "Temporary preview updated": "Temporary preview updated",
+  "Temporary preview removed": "Temporary preview removed",
+  "Expires": "Expires",
+  "Could not publish temporary preview": "Could not publish temporary preview",
+  "Could not remove temporary preview": "Could not remove temporary preview",
+  "Remove this temporary preview permanently?": "Remove this temporary preview permanently?"
 }

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -260,6 +260,7 @@
   "Apply styles that affect the entire page. These settings include global font family, text color, background color, and other universal styles that apply to all sections.": "ऐसी शैलियाँ लागू करें जो पूरे पृष्ठ को प्रभावित करती हैं। इन सेटिंग्स में वैश्विक फ़ॉन्ट परिवार, पाठ का रंग, पृष्ठभूमि का रंग और अन्य सार्वभौमिक शैलियाँ शामिल हैं जो सभी अनुभागों पर लागू होती हैं।",
   "Update Page Styles": "पृष्ठ शैलियाँ अपडेट करें",
   "Download HTML": "HTML डाउनलोड करें",
+  "Export & preview": "Export & preview",
   "Export the entire page as a standalone HTML file. This includes all sections, content, and applied styles, making it ready for use or integration elsewhere.": "पूरे पृष्ठ को एक स्टैंडअलोन HTML फ़ाइल के रूप में निर्यात करें। इसमें सभी अनुभाग, सामग्री और लागू शैलियाँ शामिल हैं, जो इसे उपयोग या अन्यत्र एकीकरण के लिए तैयार बनाता है।",
   "Download HTML file": "HTML फ़ाइल डाउनलोड करें",
   "Loading...": "लोड हो रहा है...",

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -666,6 +666,7 @@
   "Temporary preview published": "Temporary preview published",
   "Temporary preview updated": "Temporary preview updated",
   "Temporary preview removed": "Temporary preview removed",
+  "Live link": "Live link",
   "Expires": "Expires",
   "Could not publish temporary preview": "Could not publish temporary preview",
   "Could not remove temporary preview": "Could not remove temporary preview",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -260,6 +260,7 @@
   "Apply styles that affect the entire page. These settings include global font family, text color, background color, and other universal styles that apply to all sections.": "Applica stili che influenzano l'intera pagina. Queste impostazioni includono famiglia del font globale, colore del testo, colore di sfondo e altri stili universali applicati a tutte le sezioni.",
   "Update Page Styles": "Aggiorna stili della pagina",
   "Download HTML": "Scarica HTML",
+  "Export & preview": "Export & preview",
   "Export the entire page as a standalone HTML file. This includes all sections, content, and applied styles, making it ready for use or integration elsewhere.": "Esporta l'intera pagina come file HTML autonomo. Include tutte le sezioni, i contenuti e gli stili applicati, rendendolo pronto per l'uso o l'integrazione altrove.",
   "Download HTML file": "Scarica file HTML",
   "Loading...": "Caricamento...",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -652,5 +652,22 @@
   "Modern": "Modern",
   "Bold type and tighter spacing": "Tipografia bold e spaziatura più compatta",
   "Minimal": "Minimal",
-  "Quiet type and more whitespace": "Tipografia soft e più spazio bianco"
+  "Quiet type and more whitespace": "Tipografia soft e più spazio bianco",
+  "Temporary preview": "Temporary preview",
+  "Publish a public preview link that expires after 7 days. Nothing is uploaded until you click publish.": "Publish a public preview link that expires after 7 days. Nothing is uploaded until you click publish.",
+  "Publish temporary preview": "Publish temporary preview",
+  "Update temporary preview": "Update temporary preview",
+  "Publishing...": "Publishing...",
+  "Removing...": "Removing...",
+  "Copy link": "Copy link",
+  "Open preview": "Open preview",
+  "Remove preview": "Remove preview",
+  "Preview link copied": "Preview link copied",
+  "Temporary preview published": "Temporary preview published",
+  "Temporary preview updated": "Temporary preview updated",
+  "Temporary preview removed": "Temporary preview removed",
+  "Expires": "Expires",
+  "Could not publish temporary preview": "Could not publish temporary preview",
+  "Could not remove temporary preview": "Could not remove temporary preview",
+  "Remove this temporary preview permanently?": "Remove this temporary preview permanently?"
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -666,6 +666,7 @@
   "Temporary preview published": "Temporary preview published",
   "Temporary preview updated": "Temporary preview updated",
   "Temporary preview removed": "Temporary preview removed",
+  "Live link": "Live link",
   "Expires": "Expires",
   "Could not publish temporary preview": "Could not publish temporary preview",
   "Could not remove temporary preview": "Could not remove temporary preview",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -260,6 +260,7 @@
   "Apply styles that affect the entire page. These settings include global font family, text color, background color, and other universal styles that apply to all sections.": "ページ全体に影響するスタイルを適用。これらの設定には、グローバルフォントファミリー、テキストカラー、背景色、その他すべてのセクションに適用されるユニバーサルスタイルが含まれます。",
   "Update Page Styles": "ページスタイルを更新",
   "Download HTML": "HTMLをダウンロード",
+  "Export & preview": "Export & preview",
   "Export the entire page as a standalone HTML file. This includes all sections, content, and applied styles, making it ready for use or integration elsewhere.": "ページ全体をスタンドアロンのHTMLファイルとしてエクスポート。これにはすべてのセクション、コンテンツ、適用されたスタイルが含まれ、他の場所での使用や統合の準備が整います。",
   "Download HTML file": "HTMLファイルをダウンロード",
   "Loading...": "読み込み中...",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -652,5 +652,22 @@
   "Modern": "モダン",
   "Bold type and tighter spacing": "太字でコンパクトな余白",
   "Minimal": "ミニマル",
-  "Quiet type and more whitespace": "控えめな文字と広い余白"
+  "Quiet type and more whitespace": "控えめな文字と広い余白",
+  "Temporary preview": "Temporary preview",
+  "Publish a public preview link that expires after 7 days. Nothing is uploaded until you click publish.": "Publish a public preview link that expires after 7 days. Nothing is uploaded until you click publish.",
+  "Publish temporary preview": "Publish temporary preview",
+  "Update temporary preview": "Update temporary preview",
+  "Publishing...": "Publishing...",
+  "Removing...": "Removing...",
+  "Copy link": "Copy link",
+  "Open preview": "Open preview",
+  "Remove preview": "Remove preview",
+  "Preview link copied": "Preview link copied",
+  "Temporary preview published": "Temporary preview published",
+  "Temporary preview updated": "Temporary preview updated",
+  "Temporary preview removed": "Temporary preview removed",
+  "Expires": "Expires",
+  "Could not publish temporary preview": "Could not publish temporary preview",
+  "Could not remove temporary preview": "Could not remove temporary preview",
+  "Remove this temporary preview permanently?": "Remove this temporary preview permanently?"
 }

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -666,6 +666,7 @@
   "Temporary preview published": "Temporary preview published",
   "Temporary preview updated": "Temporary preview updated",
   "Temporary preview removed": "Temporary preview removed",
+  "Live link": "Live link",
   "Expires": "Expires",
   "Could not publish temporary preview": "Could not publish temporary preview",
   "Could not remove temporary preview": "Could not remove temporary preview",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -652,5 +652,22 @@
   "Modern": "Moderno",
   "Bold type and tighter spacing": "Tipografia bold e espaçamento mais apertado",
   "Minimal": "Minimalista",
-  "Quiet type and more whitespace": "Tipografia suave e mais espaço"
+  "Quiet type and more whitespace": "Tipografia suave e mais espaço",
+  "Temporary preview": "Temporary preview",
+  "Publish a public preview link that expires after 7 days. Nothing is uploaded until you click publish.": "Publish a public preview link that expires after 7 days. Nothing is uploaded until you click publish.",
+  "Publish temporary preview": "Publish temporary preview",
+  "Update temporary preview": "Update temporary preview",
+  "Publishing...": "Publishing...",
+  "Removing...": "Removing...",
+  "Copy link": "Copy link",
+  "Open preview": "Open preview",
+  "Remove preview": "Remove preview",
+  "Preview link copied": "Preview link copied",
+  "Temporary preview published": "Temporary preview published",
+  "Temporary preview updated": "Temporary preview updated",
+  "Temporary preview removed": "Temporary preview removed",
+  "Expires": "Expires",
+  "Could not publish temporary preview": "Could not publish temporary preview",
+  "Could not remove temporary preview": "Could not remove temporary preview",
+  "Remove this temporary preview permanently?": "Remove this temporary preview permanently?"
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -260,6 +260,7 @@
   "Apply styles that affect the entire page. These settings include global font family, text color, background color, and other universal styles that apply to all sections.": "Aplique estilos que afetam toda a página. Essas configurações incluem família de fontes global, cor do texto, cor de fundo e outros estilos universais aplicáveis a todas as seções.",
   "Update Page Styles": "Atualizar estilos da página",
   "Download HTML": "Baixar HTML",
+  "Export & preview": "Export & preview",
   "Export the entire page as a standalone HTML file. This includes all sections, content, and applied styles, making it ready for use or integration elsewhere.": "Exporte a página inteira como um arquivo HTML independente. Isso inclui todas as seções, conteúdo e estilos aplicados, pronto para uso ou integração em outro lugar.",
   "Download HTML file": "Baixar arquivo HTML",
   "Loading...": "Carregando...",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -666,6 +666,7 @@
   "Temporary preview published": "Temporary preview published",
   "Temporary preview updated": "Temporary preview updated",
   "Temporary preview removed": "Temporary preview removed",
+  "Live link": "Live link",
   "Expires": "Expires",
   "Could not publish temporary preview": "Could not publish temporary preview",
   "Could not remove temporary preview": "Could not remove temporary preview",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -260,6 +260,7 @@
   "Apply styles that affect the entire page. These settings include global font family, text color, background color, and other universal styles that apply to all sections.": "Применяйте стили, влияющие на всю страницу. Эти настройки включают глобальное семейство шрифтов, цвет текста, цвет фона и другие универсальные стили, применимые ко всем разделам.",
   "Update Page Styles": "Обновить стили страницы",
   "Download HTML": "Скачать HTML",
+  "Export & preview": "Export & preview",
   "Export the entire page as a standalone HTML file. This includes all sections, content, and applied styles, making it ready for use or integration elsewhere.": "Экспортируйте всю страницу как отдельный HTML-файл. Он включает все разделы, контент и применённые стили, готовые к использованию или интеграции.",
   "Download HTML file": "Скачать файл HTML",
   "Loading...": "Загрузка...",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -652,5 +652,22 @@
   "Modern": "Современный",
   "Bold type and tighter spacing": "Жирный шрифт и более плотные отступы",
   "Minimal": "Минималистичный",
-  "Quiet type and more whitespace": "Спокойная типографика и больше воздуха"
+  "Quiet type and more whitespace": "Спокойная типографика и больше воздуха",
+  "Temporary preview": "Temporary preview",
+  "Publish a public preview link that expires after 7 days. Nothing is uploaded until you click publish.": "Publish a public preview link that expires after 7 days. Nothing is uploaded until you click publish.",
+  "Publish temporary preview": "Publish temporary preview",
+  "Update temporary preview": "Update temporary preview",
+  "Publishing...": "Publishing...",
+  "Removing...": "Removing...",
+  "Copy link": "Copy link",
+  "Open preview": "Open preview",
+  "Remove preview": "Remove preview",
+  "Preview link copied": "Preview link copied",
+  "Temporary preview published": "Temporary preview published",
+  "Temporary preview updated": "Temporary preview updated",
+  "Temporary preview removed": "Temporary preview removed",
+  "Expires": "Expires",
+  "Could not publish temporary preview": "Could not publish temporary preview",
+  "Could not remove temporary preview": "Could not remove temporary preview",
+  "Remove this temporary preview permanently?": "Remove this temporary preview permanently?"
 }

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -666,6 +666,7 @@
   "Temporary preview published": "Temporary preview published",
   "Temporary preview updated": "Temporary preview updated",
   "Temporary preview removed": "Temporary preview removed",
+  "Live link": "Live link",
   "Expires": "Expires",
   "Could not publish temporary preview": "Could not publish temporary preview",
   "Could not remove temporary preview": "Could not remove temporary preview",

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -260,6 +260,7 @@
   "Apply styles that affect the entire page. These settings include global font family, text color, background color, and other universal styles that apply to all sections.": "应用影响整个页面的样式。这些设置包括全局字体家族、文本颜色、背景颜色以及适用于所有部分的通用样式。",
   "Update Page Styles": "更新页面样式",
   "Download HTML": "下载HTML",
+  "Export & preview": "Export & preview",
   "Export the entire page as a standalone HTML file. This includes all sections, content, and applied styles, making it ready for use or integration elsewhere.": "将整个页面导出为独立的HTML文件，包括所有部分、内容和应用的样式，随时可用于其他地方或集成。",
   "Download HTML file": "下载HTML文件",
   "Loading...": "加载中...",

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -666,6 +666,7 @@
   "Temporary preview published": "Temporary preview published",
   "Temporary preview updated": "Temporary preview updated",
   "Temporary preview removed": "Temporary preview removed",
+  "Live link": "Live link",
   "Expires": "Expires",
   "Could not publish temporary preview": "Could not publish temporary preview",
   "Could not remove temporary preview": "Could not remove temporary preview",

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -652,5 +652,22 @@
   "Modern": "现代",
   "Bold type and tighter spacing": "粗体字与更紧凑间距",
   "Minimal": "极简",
-  "Quiet type and more whitespace": "低调字体与更多留白"
+  "Quiet type and more whitespace": "低调字体与更多留白",
+  "Temporary preview": "Temporary preview",
+  "Publish a public preview link that expires after 7 days. Nothing is uploaded until you click publish.": "Publish a public preview link that expires after 7 days. Nothing is uploaded until you click publish.",
+  "Publish temporary preview": "Publish temporary preview",
+  "Update temporary preview": "Update temporary preview",
+  "Publishing...": "Publishing...",
+  "Removing...": "Removing...",
+  "Copy link": "Copy link",
+  "Open preview": "Open preview",
+  "Remove preview": "Remove preview",
+  "Preview link copied": "Preview link copied",
+  "Temporary preview published": "Temporary preview published",
+  "Temporary preview updated": "Temporary preview updated",
+  "Temporary preview removed": "Temporary preview removed",
+  "Expires": "Expires",
+  "Could not publish temporary preview": "Could not publish temporary preview",
+  "Could not remove temporary preview": "Could not remove temporary preview",
+  "Remove this temporary preview permanently?": "Remove this temporary preview permanently?"
 }

--- a/src/tests/demo/PageBuilderTest.vue
+++ b/src/tests/demo/PageBuilderTest.vue
@@ -124,6 +124,7 @@ watch(
         :CustomMediaLibraryComponent="DemoMediaLibraryComponentTest"
         :DisplayProducts="DemoDisplayProductsTest"
         :showPublishButton="true"
+        :showTemporaryPreviewButton="true"
         :showCloseButton="true"
         @handlePublishPageBuilder="publishPageBuilder"
       />

--- a/src/tests/utils/standalone-html.test.ts
+++ b/src/tests/utils/standalone-html.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildStandaloneHtml,
+  collectDocumentStyles,
+  downloadStandaloneHtml,
+  extractStandalonePageContent,
+} from '../../utils/builder/standalone-html'
+
+describe('standalone HTML', () => {
+  beforeEach(() => {
+    document.head.innerHTML = ''
+    document.body.innerHTML = ''
+  })
+
+  it('collects inline and linked document styles', () => {
+    document.head.innerHTML = `
+      <style>.example { color: red; }</style>
+      <link rel="stylesheet" href="/theme.css">
+    `
+
+    const styles = collectDocumentStyles(document)
+    expect(styles).toContain('.example { color: red; }')
+    expect(styles).toContain(new URL('/theme.css', document.baseURI).href)
+  })
+
+  it('removes editor-only state and produces a standalone document', () => {
+    document.body.innerHTML = `
+      <div id="pagebuilder">
+        <section data-componentid="hero" selected hovered>Hello</section>
+        <div data-pbx-insert-btn>Insert</div>
+      </div>
+    `
+    const pagebuilder = document.getElementById('pagebuilder') as HTMLElement
+    const content = extractStandalonePageContent(pagebuilder)
+    const html = buildStandaloneHtml(content, document, 'A <Page>')
+
+    expect(html).toContain('<!DOCTYPE html>')
+    expect(html).toContain('<title>A &lt;Page&gt;</title>')
+    expect(html).toContain('Hello')
+    expect(html).not.toContain('selected')
+    expect(html).not.toContain('hovered')
+    expect(html).not.toContain('data-componentid')
+    expect(html).not.toContain('Insert')
+  })
+
+  it('downloads the supplied standalone document', () => {
+    const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+    downloadStandaloneHtml('page.html', '<html>Page</html>', document)
+
+    expect(click).toHaveBeenCalledOnce()
+    expect(document.querySelector('a')).toBeNull()
+  })
+})

--- a/src/tests/utils/temp-preview.test.ts
+++ b/src/tests/utils/temp-preview.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  isExpiredPreviewCredential,
+  loadTemporaryPreview,
+  publishTemporaryPreview,
+  removeTemporaryPreview,
+  saveTemporaryPreview,
+  TemporaryPreviewError,
+} from '../../utils/builder/temp-preview'
+import type { TemporaryPreview } from '../../utils/builder/temp-preview'
+
+const preview: TemporaryPreview = {
+  tempId: 'temp_123',
+  canonicalUrl: 'https://example.temp.md',
+  updateToken: 'tempmd_secret',
+  expiresAt: '2026-08-31T12:00:00.000Z',
+}
+
+describe('temporary previews', () => {
+  const values = new Map<string, string>()
+  const storage = {
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => values.set(key, value)),
+    removeItem: vi.fn((key: string) => values.delete(key)),
+    clear: vi.fn(() => values.clear()),
+    key: vi.fn(() => null),
+    get length() {
+      return values.size
+    },
+  } satisfies Storage
+
+  beforeEach(() => {
+    values.clear()
+    vi.clearAllMocks()
+  })
+
+  it('publishes standalone HTML as a multipart file', async () => {
+    const fetcher = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(preview), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    await expect(
+      publishTemporaryPreview('<html>Hello</html>', undefined, { fetcher }),
+    ).resolves.toEqual(preview)
+
+    expect(fetcher).toHaveBeenCalledOnce()
+    const [url, request] = fetcher.mock.calls[0]
+    expect(url).toBe('https://api.temp.md/temps')
+    expect(request.method).toBe('POST')
+    expect(request.body).toBeInstanceOf(FormData)
+    expect((request.body as FormData).get('file')).toBeInstanceOf(Blob)
+  })
+
+  it('updates the same URL with its scoped token', async () => {
+    const fetcher = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ canonicalUrl: preview.canonicalUrl }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    await expect(
+      publishTemporaryPreview('<html>Updated</html>', preview, { fetcher }),
+    ).resolves.toEqual(preview)
+
+    const [url, request] = fetcher.mock.calls[0]
+    expect(url).toBe('https://api.temp.md/temps/temp_123')
+    expect(request.method).toBe('PUT')
+    expect(request.headers).toEqual({ Authorization: 'Bearer tempmd_secret' })
+  })
+
+  it('removes an existing preview and accepts an already-gone response', async () => {
+    const fetcher = vi.fn().mockResolvedValue(new Response(null, { status: 404 }))
+    await removeTemporaryPreview(preview, { fetcher })
+
+    expect(fetcher).toHaveBeenCalledWith('https://api.temp.md/temps/temp_123', {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer tempmd_secret' },
+    })
+  })
+
+  it('identifies credentials that should fall back to a fresh preview', () => {
+    expect(isExpiredPreviewCredential(new TemporaryPreviewError('Gone', 410))).toBe(true)
+    expect(isExpiredPreviewCredential(new TemporaryPreviewError('Server error', 500))).toBe(false)
+  })
+
+  it('persists the scoped update capability locally', () => {
+    saveTemporaryPreview('preview-key', preview, storage)
+    expect(loadTemporaryPreview('preview-key', storage)).toEqual(preview)
+    saveTemporaryPreview('preview-key', null, storage)
+    expect(loadTemporaryPreview('preview-key', storage)).toBeNull()
+  })
+})

--- a/src/utils/builder/standalone-html.ts
+++ b/src/utils/builder/standalone-html.ts
@@ -1,0 +1,99 @@
+import { extractCleanHTMLFromPageBuilder } from './extract-clean-html'
+
+const PAGE_RESET_CSS = `
+      <style>
+        #pagebuilder blockquote,
+        #pagebuilder dl,
+        #pagebuilder dd,
+        #pagebuilder pre,
+        #pagebuilder hr,
+        #pagebuilder figure,
+        #pagebuilder p,
+        #pagebuilder h1,
+        #pagebuilder h2,
+        #pagebuilder h3,
+        #pagebuilder h4,
+        #pagebuilder h5,
+        #pagebuilder h6,
+        #pagebuilder ul,
+        #pagebuilder ol {
+          margin: 0;
+          padding: 0;
+        }
+      </style>
+    `
+
+export function collectDocumentStyles(sourceDocument: Document = document): string {
+  return Array.from(sourceDocument.querySelectorAll('style, link[rel="stylesheet"]'))
+    .map((style) => {
+      if (style.tagName === 'STYLE') return style.outerHTML
+      if (style.tagName === 'LINK') {
+        return `<link rel="stylesheet" href="${(style as HTMLLinkElement).href}">`
+      }
+      return ''
+    })
+    .join('\n')
+}
+
+export function extractStandalonePageContent(pagebuilder: HTMLElement): string {
+  const tempDiv = pagebuilder.ownerDocument.createElement('div')
+  tempDiv.innerHTML = extractCleanHTMLFromPageBuilder(pagebuilder)
+  tempDiv.querySelectorAll('[hovered], [selected]').forEach((element) => {
+    element.removeAttribute('hovered')
+    element.removeAttribute('selected')
+  })
+  return tempDiv.innerHTML
+}
+
+export function buildStandaloneHtml(
+  contentHtml: string,
+  sourceDocument: Document = document,
+  title = 'Downloaded HTML',
+): string {
+  const styles = `${collectDocumentStyles(sourceDocument)}\n${PAGE_RESET_CSS}`
+  const escapedTitle = title
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;')
+
+  return `
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>${escapedTitle}</title>
+            ${styles}
+        </head>
+        <body>
+            <div id="pagebuilder" class="pbx-font-sans pbx-text-black">
+                ${contentHtml}
+            </div>
+        </body>
+        </html>
+    `
+}
+
+export function getStandalonePageHtml(
+  pagebuilder: HTMLElement,
+  sourceDocument: Document = document,
+  title?: string,
+): string {
+  return buildStandaloneHtml(extractStandalonePageContent(pagebuilder), sourceDocument, title)
+}
+
+export function downloadStandaloneHtml(
+  filename: string,
+  html: string,
+  sourceDocument: Document = document,
+): void {
+  const element = sourceDocument.createElement('a')
+  element.setAttribute('href', `data:text/html;charset=utf-8,${encodeURIComponent(html)}`)
+  element.setAttribute('download', filename)
+  element.style.display = 'none'
+  sourceDocument.body.appendChild(element)
+  element.click()
+  sourceDocument.body.removeChild(element)
+}

--- a/src/utils/builder/temp-preview.ts
+++ b/src/utils/builder/temp-preview.ts
@@ -1,0 +1,137 @@
+const DEFAULT_API_URL = 'https://api.temp.md'
+
+export interface TemporaryPreview {
+  tempId: string
+  canonicalUrl: string
+  updateToken: string
+  expiresAt?: string | null
+}
+
+export interface TemporaryPreviewOptions {
+  apiUrl?: string
+  fetcher?: typeof fetch
+}
+
+export class TemporaryPreviewError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message)
+    this.name = 'TemporaryPreviewError'
+  }
+}
+
+async function readResponse(response: Response): Promise<Record<string, unknown>> {
+  const body = (await response.json().catch(() => ({}))) as Record<string, unknown>
+  if (!response.ok) {
+    const message =
+      typeof body.error === 'string'
+        ? body.error
+        : typeof body.message === 'string'
+          ? body.message
+          : `Temporary preview request failed (${response.status})`
+    throw new TemporaryPreviewError(message, response.status)
+  }
+  return body
+}
+
+function parsePreview(
+  body: Record<string, unknown>,
+  previous?: TemporaryPreview,
+): TemporaryPreview {
+  const tempId = typeof body.tempId === 'string' ? body.tempId : previous?.tempId
+  const canonicalUrl =
+    typeof body.canonicalUrl === 'string' ? body.canonicalUrl : previous?.canonicalUrl
+  const updateToken =
+    typeof body.updateToken === 'string' ? body.updateToken : previous?.updateToken
+
+  if (!tempId || !canonicalUrl || !updateToken) {
+    throw new TemporaryPreviewError('Temporary preview returned an invalid response', 502)
+  }
+
+  return {
+    tempId,
+    canonicalUrl,
+    updateToken,
+    expiresAt:
+      typeof body.expiresAt === 'string' || body.expiresAt === null
+        ? body.expiresAt
+        : previous?.expiresAt,
+  }
+}
+
+export async function publishTemporaryPreview(
+  html: string,
+  previous?: TemporaryPreview,
+  options: TemporaryPreviewOptions = {},
+): Promise<TemporaryPreview> {
+  const fetcher = options.fetcher ?? fetch
+  const apiUrl = (options.apiUrl ?? DEFAULT_API_URL).replace(/\/$/, '')
+  const body = new FormData()
+  body.append('file', new Blob([html], { type: 'text/html' }), 'index.html')
+
+  const response = await fetcher(
+    previous ? `${apiUrl}/temps/${encodeURIComponent(previous.tempId)}` : `${apiUrl}/temps`,
+    {
+      method: previous ? 'PUT' : 'POST',
+      headers: previous ? { Authorization: `Bearer ${previous.updateToken}` } : undefined,
+      body,
+    },
+  )
+
+  return parsePreview(await readResponse(response), previous)
+}
+
+export async function removeTemporaryPreview(
+  preview: TemporaryPreview,
+  options: TemporaryPreviewOptions = {},
+): Promise<void> {
+  const fetcher = options.fetcher ?? fetch
+  const apiUrl = (options.apiUrl ?? DEFAULT_API_URL).replace(/\/$/, '')
+  const response = await fetcher(`${apiUrl}/temps/${encodeURIComponent(preview.tempId)}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${preview.updateToken}` },
+  })
+
+  if (response.status === 404 || response.status === 410) return
+  await readResponse(response)
+}
+
+export function isExpiredPreviewCredential(error: unknown): boolean {
+  return error instanceof TemporaryPreviewError && [401, 403, 404, 410].includes(error.status)
+}
+
+function getBrowserStorage(): Storage | null {
+  try {
+    return typeof window === 'undefined' ? null : window.localStorage
+  } catch {
+    return null
+  }
+}
+
+export function loadTemporaryPreview(
+  storageKey: string,
+  storage: Storage | null = getBrowserStorage(),
+): TemporaryPreview | null {
+  try {
+    const value = storage?.getItem(storageKey)
+    if (!value) return null
+    return parsePreview(JSON.parse(value) as Record<string, unknown>)
+  } catch {
+    return null
+  }
+}
+
+export function saveTemporaryPreview(
+  storageKey: string,
+  preview: TemporaryPreview | null,
+  storage: Storage | null = getBrowserStorage(),
+): void {
+  try {
+    if (preview) storage?.setItem(storageKey, JSON.stringify(preview))
+    else storage?.removeItem(storageKey)
+  } catch {
+    // Storage can be unavailable in embedded or privacy-restricted contexts.
+  }
+}


### PR DESCRIPTION
Closes #265

## Summary

- add a default-off `showTemporaryPreviewButton` prop
- reuse the existing standalone HTML export for browser-initiated Temp.md previews
- create, update, copy, open, and permanently remove a preview
- retain the scoped update capability in browser storage and recover from stale capabilities by creating a fresh link
- document the opt-in integration and add locale-key coverage
- leave the existing host-controlled Publish callback unchanged

## Privacy and lifecycle

Nothing is uploaded until the editor explicitly clicks Publish temporary preview. The UI states that the resulting link is public and expires after 7 days. The update capability remains local to the browser.

## Verification

- `npm run type-check`
- `npm run build`
- focused Vitest suite: 8/8 passing
- ESLint on changed TypeScript/Vue files
- Prettier and locale-key checks

The repository-wide suite also has an unrelated Node 26/jsdom environment failure: existing tests that call the global `localStorage` fail before their assertions because that global is unavailable. The focused new tests avoid relying on that broken global and pass.

## Affiliation

I am affiliated with Temp.md, the service used by this optional integration.